### PR TITLE
「陽性患者数」「陽性患者の属性」カードにオープンデータへのリンクを追加 しました。

### DIFF
--- a/components/DataTable.vue
+++ b/components/DataTable.vue
@@ -38,7 +38,7 @@
       />
     </template>
     <template v-slot:footer>
-      <!--<open-data-link :url="url" />-->
+      <open-data-link :url="url" />
     </template>
   </data-view>
 </template>
@@ -102,12 +102,10 @@
 import Vue from 'vue'
 import DataView from '@/components/DataView.vue'
 import DataViewBasicInfoPanel from '@/components/DataViewBasicInfoPanel.vue'
-/*
 import OpenDataLink from '@/components/OpenDataLink.vue'
-*/
 
 export default Vue.extend({
-  components: { DataView, DataViewBasicInfoPanel /* OpenDataLink */ },
+  components: { DataView, DataViewBasicInfoPanel, OpenDataLink },
   props: {
     title: {
       type: String,

--- a/components/cards/ConfirmedCasesAttributesCard.vue
+++ b/components/cards/ConfirmedCasesAttributesCard.vue
@@ -7,6 +7,10 @@
         :chart-data="patientsTable"
         :chart-option="{}"
         :date="Patients.date"
+        :url="
+          'http://www.okayama-opendata.jp/opendata/ga120PreAction.action?keyTitle=d9c4776db7f09fff161953a2aaf03b80a9abad48&datasetId=e6b3c1d2-2f1f-4735-b36e-e45d36d94761'
+        "
+	:source="$t('オープンデータを入手')"
         :info="sumInfoOfPatients"
         :custom-sort="customSort"
       />

--- a/components/cards/ConfirmedCasesAttributesCard.vue
+++ b/components/cards/ConfirmedCasesAttributesCard.vue
@@ -10,7 +10,7 @@
         :url="
           'http://www.okayama-opendata.jp/opendata/ga120PreAction.action?keyTitle=d9c4776db7f09fff161953a2aaf03b80a9abad48&datasetId=e6b3c1d2-2f1f-4735-b36e-e45d36d94761'
         "
-	:source="$t('オープンデータを入手')"
+        :source="$t('オープンデータを入手')"
         :info="sumInfoOfPatients"
         :custom-sort="customSort"
       />

--- a/components/cards/ConfirmedCasesNumberCard.vue
+++ b/components/cards/ConfirmedCasesNumberCard.vue
@@ -7,6 +7,7 @@
       :chart-data="patientsGraph"
       :date="PatientsSummary.date"
       :unit="$t('人')"
+      :url="'http://www.okayama-opendata.jp/opendata/ga120PreAction.action?keyTitle=d9c4776db7f09fff161953a2aaf03b80a9abad48&datasetId=e6b3c1d2-2f1f-4735-b36e-e45d36d94761'"
     />
   </v-col>
 </template>

--- a/components/cards/ConfirmedCasesNumberCard.vue
+++ b/components/cards/ConfirmedCasesNumberCard.vue
@@ -7,7 +7,9 @@
       :chart-data="patientsGraph"
       :date="PatientsSummary.date"
       :unit="$t('人')"
-      :url="'http://www.okayama-opendata.jp/opendata/ga120PreAction.action?keyTitle=d9c4776db7f09fff161953a2aaf03b80a9abad48&datasetId=e6b3c1d2-2f1f-4735-b36e-e45d36d94761'"
+      :url="
+        'http://www.okayama-opendata.jp/opendata/ga120PreAction.action?keyTitle=d9c4776db7f09fff161953a2aaf03b80a9abad48&datasetId=e6b3c1d2-2f1f-4735-b36e-e45d36d94761'
+      "
     />
   </v-col>
 </template>


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #129

## 📝 関連する issue / Related Issues
- (関連するissueはありません)

## ⛏ 変更内容 / Details of Changes
 - 「陽性患者数」「陽性患者の属性」カードにオープンデータへのリンクを追加しました。
追加したリンクは他のカードと同じく、以下のURLとしています。
   - [新型コロナウイルス感染症に関するデータ（岡山県）](http://www.okayama-opendata.jp/opendata/ga120PreAction.action?keyTitle=d9c4776db7f09fff161953a2aaf03b80a9abad48&datasetId=e6b3c1d2-2f1f-4735-b36e-e45d36d94761)
 - また、「検査陽性者の状況」カードについては、まだ[東京版](https://stopcovid19.metro.tokyo.lg.jp/)にもリンクが実装されていないため、リンクは追加せず、そのままにしています。

## 📸 スクリーンショット / Screenshots
以下の画像で緑色の枠で囲っている個所が今回追加したリンクになります。

 * [岡山県版 新型コロナウイルス感染症対策サイト（非公式）](https://okayama.stopcovid19.jp/)

![img](https://user-images.githubusercontent.com/772589/79973458-8d7d0200-84d2-11ea-94f3-1ec642481fb0.png)
