### PR TITLE
陽性患者の属性カードから退院カラムを消しました。

### DIFF
--- a/components/DataTable.vue
+++ b/components/DataTable.vue
@@ -157,17 +157,6 @@ export default Vue.extend({
       }
     }
   },
-  created() {
-    // 「陽性患者の属性」カードにおいて、「退院」のデータが存在しないため、
-    // createdライフサイクルフックの段階で「退院」のヘッダを除去する。
-    this.chartData.headers.forEach((header: any, index: Number) => {
-      if (header.text === '退院※') {
-        // ヘッダデータの要素の並び順が変わる可能性を想定し、
-        // 各要素の中で「退院」のテキストを特定してから除去する。
-        this.chartData.headers.splice(index, 1)
-      }
-    })
-  },
   mounted() {
     const vTables = this.$refs.displayedTable as Vue
     const vTableElement = vTables.$el

--- a/components/DataTable.vue
+++ b/components/DataTable.vue
@@ -22,14 +22,18 @@
             <td class="text-start">{{ item['居住地'] }}</td>
             <td class="text-start">{{ item['年代'] }}</td>
             <td class="text-start">{{ item['性別'] }}</td>
+            <!--
             <td class="text-center">{{ item['退院'] }}</td>
+            -->
           </tr>
         </tbody>
       </template>
     </v-data-table>
+    <!--
     <div class="note">
       {{ $t('※退院には、死亡退院を含む') }}
     </div>
+    -->
     <template v-slot:infoPanel>
       <data-view-basic-info-panel
         :l-text="info.lText"
@@ -152,6 +156,17 @@ export default Vue.extend({
         return items
       }
     }
+  },
+  created() {
+    // 「陽性患者の属性」カードにおいて、「退院」のデータが存在しないため、
+    // createdライフサイクルフックの段階で「退院」のヘッダを除去する。
+    this.chartData.headers.forEach((header: any, index: Number) => {
+      if (header.text === '退院※') {
+        // ヘッダデータの要素の並び順が変わる可能性を想定し、
+        // 各要素の中で「退院」のテキストを特定してから除去する。
+        this.chartData.headers.splice(index, 1)
+      }
+    })
   },
   mounted() {
     const vTables = this.$refs.displayedTable as Vue

--- a/utils/formatTable.ts
+++ b/utils/formatTable.ts
@@ -4,8 +4,8 @@ const headers = [
   { text: '公表日', value: '公表日' },
   { text: '居住地', value: '居住地' },
   { text: '年代', value: '年代' },
-  { text: '性別', value: '性別' },
-  { text: '退院※', value: '退院', align: 'center' }
+  { text: '性別', value: '性別' }
+  // { text: '退院※', value: '退院', align: 'center' }
 ]
 
 type DataType = {
@@ -13,7 +13,7 @@ type DataType = {
   居住地: string | null
   年代: string | null
   性別: '男性' | '女性' | string
-  退院: '◯' | null
+  // 退院: '◯' | null
   [key: string]: any
 }
 
@@ -22,7 +22,7 @@ type TableDataType = {
   居住地: DataType['居住地']
   年代: DataType['年代']
   性別: DataType['性別'] | '不明'
-  退院: DataType['退院']
+  // 退院: DataType['退院']
 }
 
 type TableDateType = {
@@ -45,8 +45,8 @@ export default (data: DataType[]) => {
       公表日: dayjs(d['リリース日']).format('M/D') ?? '不明',
       居住地: d['居住地'] ?? '調査中',
       年代: d['年代'] ?? '不明',
-      性別: d['性別'] ?? '不明',
-      退院: d['退院']
+      性別: d['性別'] ?? '不明'
+      // 退院: d['退院']
     }
     tableDate.datasets.push(TableRow)
   })


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #174

## 📝 関連する issue / Related Issues
- (関連するissueはありません)

## ⛏ 変更内容 / Details of Changes
- 現状では退院のデータがJSONに存在しないため、陽性患者の属性カードから「退院※」のカラムを除去しました。
  - 併せて「※退院には、死亡退院を含む」の補足説明も除去しています。
- あとで退院データが入手できるようになった場合を想定し、既存のコードをコメントアウトする方法で修正しています。

## 📸 スクリーンショット / Screenshots

- 修正前(赤枠で囲んだ部分が今回除去した個所です)
![img01](https://user-images.githubusercontent.com/772589/80381406-dae6de00-88db-11ea-9585-bf4a08f446f4.png)

- 修正後
![img02](https://user-images.githubusercontent.com/772589/80381416-de7a6500-88db-11ea-8c6f-080ed0d2e106.png)
