### PR TITLE
「岡山県緊急事態措置について」リンク撤去

### DIFF
--- a/components/WhatsNew.vue
+++ b/components/WhatsNew.vue
@@ -7,16 +7,6 @@
         </v-icon>
         {{ $t('最新のお知らせ') }}
       </h3>
-      <span class="WhatsNew-link-to-emergency-page">
-        <v-icon size="20" class="WhatsNew-link-to-emergency-page-icon">
-          mdi-bullhorn
-        </v-icon>
-        <external-link
-          url="https://youtu.be/mUwVyGTMWn8"
-        >
-          {{ $t('岡山県緊急事態措置について') }}
-        </external-link>
-      </span>
     </div>
     <ul class="WhatsNew-list">
       <li v-for="(item, i) in items" :key="i" class="WhatsNew-list-item">


### PR DESCRIPTION
「岡山県緊急事態措置について」リンク撤去

<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #290

## 📝 関連する issue / Related Issues
- #290 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 「岡山県緊急事態措置について」のリンクを撤去しました。

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
![image](https://user-images.githubusercontent.com/34095156/84898614-82b1a880-b0e2-11ea-9a24-e7da46e3db8a.png)

